### PR TITLE
Added support for Rack::File body to Tipi::RackAdapter

### DIFF
--- a/lib/tipi/rack_adapter.rb
+++ b/lib/tipi/rack_adapter.rb
@@ -68,10 +68,18 @@ module Tipi
         else                       RACK_ENV[key]
         end
       end
-      
+
       def respond(request, (status_code, headers, body))
         headers[':status'] = status_code.to_s
-        request.respond(body.first, headers)
+
+        content =
+          if body.respond_to?(:to_path)
+            File.open(body.to_path, 'rb') { |f| f.read }
+          else
+            body.first
+          end
+
+        request.respond(content, headers)
       end
     end
   end


### PR DESCRIPTION
Hi guys, thanks for the really cool project! I've been having some fun with polyphony, and in the last couple of days tipi also.
I think using monkey patching to hide all the evented IO stuff really makes it very easy and ruby-like to use from an outside developer's perspective.

I've been trying tipi with a simple web app and found that it crashes if the app tries to serve a static file using Rack::File.

Here's a simple `config.ru` that can be used to replicate the issue. This should serve any files present in the current directory:
```
app = Rack::Builder.app do
  use Rack::Static, urls: ['/']
  run ->(env) { [200, {'Content-Type' => 'text/plain'}, ['OK']] }
end

run app
```
With that in place you can just run `tipi` on the same directory as the `config.ru` file and test (this should show the content of the `config.ru` file):
```
curl localhost:1234/config.ru
```


The PR itself is pretty simple: It just adds a check in `Tipi::RackAdapter#respond` to see if the response is a Rack::File, and if that's the case it reads the file and responds with the contents. Otherwise the behaviour is unchanged.

I wanted to add a test for this but it looks like the test suite is still in its early stages and I didn't have a straightforward way to setup the test. If you think this PR could be a good thing to merge I'll try adding a test in the weekend if I can get a couple of free hours :)