### PR TITLE
Example fixes

### DIFF
--- a/examples/http_server_forked.rb
+++ b/examples/http_server_forked.rb
@@ -11,11 +11,13 @@ opts = {
   dont_linger: true
 }
 
+server = Tipi.listen('0.0.0.0', 1234, opts)
+
 child_pids = []
 8.times do
   pid = Polyphony.fork do
     puts "forked pid: #{Process.pid}"
-    Tipi.serve('0.0.0.0', 1234, opts) do |req|
+    server.each do |req|
       req.respond("Hello world! from pid: #{Process.pid}\n")
     end
   rescue Interrupt

--- a/examples/websocket_demo.rb
+++ b/examples/websocket_demo.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-require 'bundler/inline'
-
-gemfile do
-  source 'https://rubygems.org'
-  gem 'polyphony', '~> 0.44'
-  gem 'tipi', '~> 0.31'
-end
-
+require 'bundler/setup'
+require 'tipi'
 require 'tipi/websocket'
 
 class WebsocketClient

--- a/examples/ws_page.html
+++ b/examples/ws_page.html
@@ -6,7 +6,7 @@
 <body>
   <script>
     var connect = function () {
-      var exampleSocket = new WebSocket("wss://dev.realiteq.net/");
+      var exampleSocket = new WebSocket("ws://localhost:4411/");
 
       exampleSocket.onopen = function (event) {
         document.querySelector('#status').innerText = 'connected';


### PR DESCRIPTION
Fix three problems in the Tipi example set:

- Correct the target URL in the websocket client page `ws_page.html`.

- Directly require dependencies for the `websocket_demo.rb` example.

- Align the code structure for `http_server_forked.rb` with that used in the `https_server_forked.rb` and `rack_server_https_forked.rb` examples, which also fixes a problem when running on MacOS.